### PR TITLE
Add Module to limit max. number of AI trade track cards to 2

### DIFF
--- a/src/components/round/DebugInfo.vue
+++ b/src/components/round/DebugInfo.vue
@@ -21,9 +21,9 @@ import { defineComponent, PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { CardDeckPersistence, useStateStore } from '@/store/state'
 import Bot from '@/services/Bot'
-import Cards from '@/services/Cards';
-import Card from '@/services/Card';
-import CardName from '@/services/enum/CardName';
+import Cards from '@/services/Cards'
+import Card from '@/services/Card'
+import CardName from '@/services/enum/CardName'
 
 export default defineComponent({
   name: 'DebugInfo',

--- a/src/components/setup/SelectExpansion.vue
+++ b/src/components/setup/SelectExpansion.vue
@@ -64,7 +64,7 @@ export default defineComponent({
     toggleAfricanEmpires() {
       this.state.setupToggleExpansionAfricanEmpires()
       if (!this.hasAfricanEmpires) {
-        this.state.setup.modules = this.state.setup.modules.filter(module => ![Module.NATURAL_WONDERS,Module.FUTURE_ERA,Module.QUESTS].includes(module))
+        this.state.setup.modules = this.state.setup.modules.filter(module => ![Module.NATURAL_WONDERS,Module.FUTURE_ERA,Module.QUESTS,Module.LIMIT_TRADE_TRACK_CARDS].includes(module))
       }
     }
   }

--- a/src/components/setup/SelectExpansion.vue
+++ b/src/components/setup/SelectExpansion.vue
@@ -40,7 +40,7 @@ import { defineComponent } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStateStore } from '@/store/state'
 import Expansion from '@/services/enum/Expansion'
-import Module from '@/services/enum/Module';
+import Module from '@/services/enum/Module'
 
 export default defineComponent({
   name: 'SelectExpansion',

--- a/src/components/setup/SelectModules.vue
+++ b/src/components/setup/SelectModules.vue
@@ -3,8 +3,8 @@
   <div class="row">
     <div class="col">
       <div class="form-check form-switch form-check-inline" v-for="item of modules" :key="item">
-        <label class="form-check-label" :class="{'text-muted':!isAvailable(item)}">
-          <input class="form-check-input" type="checkbox" :checked="hasModule(item)" @input="toggleModule(item)" :disabled="!isAvailable(item)">
+        <input class="form-check-input" type="checkbox" :checked="hasModule(item)" @input="toggleModule(item)" :disabled="!isAvailable(item)" :id="`module-${item}`">
+        <label class="form-check-label" :class="{'text-muted':!isAvailable(item)}" :for="`module-${item}`">
           <span v-html="t(`module.${item}`)"></span>
         </label>
       </div>
@@ -51,7 +51,7 @@ export default defineComponent({
       toggleArrayItem(this.state.setup.modules, module)
     },
     isAvailable(module : Module) : boolean {
-      if ([Module.NATURAL_WONDERS,Module.FUTURE_ERA,Module.QUESTS].includes(module)) {
+      if ([Module.NATURAL_WONDERS,Module.FUTURE_ERA,Module.QUESTS,Module.LIMIT_TRADE_TRACK_CARDS].includes(module)) {
         return this.hasAfricanEmpiresExpansion
       }
       return true

--- a/src/components/setup/SelectModules.vue
+++ b/src/components/setup/SelectModules.vue
@@ -2,10 +2,10 @@
   <h3 class="mt-4 mb-3">{{t('setup.selectModules.title')}}</h3>
   <div class="row">
     <div class="col">
-      <div class="form-check form-switch" v-for="item of modules" :key="item">
+      <div class="form-check form-switch form-check-inline" v-for="item of modules" :key="item">
         <label class="form-check-label" :class="{'text-muted':!isAvailable(item)}">
           <input class="form-check-input" type="checkbox" :checked="hasModule(item)" @input="toggleModule(item)" :disabled="!isAvailable(item)">
-          {{t(`module.${item}`)}}
+          <span v-html="t(`module.${item}`)"></span>
         </label>
       </div>
     </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -180,7 +180,8 @@
     "heroes": "Heroes",
     "natural-wonders": "Natural Wonders",
     "future-era": "Future Era Cards",
-    "quests": "Quests"
+    "quests": "Quests",
+    "limit-trade-track-cards": "Limit to 2 Automa Trade Track cards (<a href='https://boardgamegeek.com/thread/3290654' target='_blank' rel='noopener'>see BGG</a>)"
   },
   "action": {
     "playGame": "Play Game",

--- a/src/services/enum/Module.ts
+++ b/src/services/enum/Module.ts
@@ -3,6 +3,7 @@ enum Module {
   HEROES = 'heroes',
   NATURAL_WONDERS = 'natural-wonders',
   FUTURE_ERA = 'future-era',
-  QUESTS = 'quests'
+  QUESTS = 'quests',
+  LIMIT_TRADE_TRACK_CARDS = 'limit-trade-track-cards'
 }
 export default Module

--- a/tests/unit/services/CardDeck.spec.ts
+++ b/tests/unit/services/CardDeck.spec.ts
@@ -3,17 +3,36 @@ import CardDeck from '@/services/CardDeck'
 import { expect } from 'chai'
 import Cards from '@/services/Cards'
 import Module from '@/services/enum/Module'
+import Expansion from '@/services/enum/Expansion'
+import Action from '@/services/enum/Action'
 
 describe('CardDeck', () => {
   it('newShuffled', () => {
-    const cardDeck = CardDeck.new(3, [], [Module.HEROES])
+    const cardDeck = CardDeck.new(3, [Expansion.AFRICAN_EMPIRES], [Module.HEROES])
 
-    expect(cardDeck.drawPile.length).to.eq(20)
+    expect(cardDeck.drawPile.length).to.eq(27)
     expect(cardDeck.discardPile.length).to.eq(0)
     expect(cardDeck.openCards.length).to.eq(0)
 
     const persistence = cardDeck.toPersistence()
-    expect(persistence.drawPile.length).to.eq(20)
+    expect(persistence.drawPile.length).to.eq(27)
+    expect(persistence.discardPile.length).to.eq(0)
+    expect(persistence.openCards.length).to.eq(0)
+    expect(persistence.nexusCards.length).to.eq(0)
+
+    expect(persistence.drawPile.includes(CardName.MULTI_AUTOMA)).to.true
+  })
+
+  it('newShuffled_limitTradeTrackCards', () => {
+    const cardDeck = CardDeck.new(3, [Expansion.AFRICAN_EMPIRES], [Module.HEROES,Module.LIMIT_TRADE_TRACK_CARDS])
+
+    expect(cardDeck.drawPile.length).to.eq(24)
+    expect(cardDeck.discardPile.length).to.eq(0)
+    expect(cardDeck.openCards.length).to.eq(0)
+    expect(cardDeck.drawPile.filter(card => card.actions.filter(action => action.action == Action.TRADE_TRACK_1_STEP).length == 3).length).to.eq(2)
+
+    const persistence = cardDeck.toPersistence()
+    expect(persistence.drawPile.length).to.eq(24)
     expect(persistence.discardPile.length).to.eq(0)
     expect(persistence.openCards.length).to.eq(0)
     expect(persistence.nexusCards.length).to.eq(0)


### PR DESCRIPTION
as proposed on BGG: https://boardgamegeek.com/thread/3290654
this is an unofficial variant

new i18n keys:
```
module.limit-trade-track-cards
```